### PR TITLE
ignore default namespace creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.5.0
+        uses: helm/chart-testing-action@v2.4.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed

--- a/charts/namespaces/Chart.yaml
+++ b/charts/namespaces/Chart.yaml
@@ -1,18 +1,11 @@
 apiVersion: v2
 name: namespaces
 description: A chart to factor out the boilerplate of managing namespaces and associated resourceQuotas
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
+maintainers:
+- name: cyclingwithelephants
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0

--- a/charts/namespaces/templates/namespace.yaml
+++ b/charts/namespaces/templates/namespace.yaml
@@ -1,4 +1,5 @@
 {{- range .Values.namespaces }}
+  {{- if not (has .name (list "default" "kube-system" "kube-public" "kube-node-lease"))}}
 ---
 apiVersion: v1
 kind: Namespace
@@ -11,4 +12,5 @@ metadata:
     {{- if .labels }}
       {{- toYaml .labels | nindent 4 }}
     {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/namespaces/templates/resource-quota.yaml
+++ b/charts/namespaces/templates/resource-quota.yaml
@@ -6,8 +6,8 @@ metadata:
   name: {{ .name | quote }}
 spec:
   hard:
-    requests.cpu:    {{- if .requests }} {{ default $.Values.defaults.requests.cpu .requests.cpu | quote }}       {{- else }} {{ $.Values.defaults.requests.cpu | quote }}    {{- end }}
+    requests.cpu:    {{- if .requests }} {{ default $.Values.defaults.requests.cpu    .requests.cpu    | quote }} {{- else }} {{ $.Values.defaults.requests.cpu    | quote }} {{- end }}
     requests.memory: {{- if .requests }} {{ default $.Values.defaults.requests.memory .requests.memory | quote }} {{- else }} {{ $.Values.defaults.requests.memory | quote }} {{- end }}
-    limits.cpu:      {{- if .limits }}   {{ default $.Values.defaults.limits.cpu .limits.cpu | quote }}           {{- else }} {{ $.Values.defaults.limits.cpu | quote }}      {{- end }}
-    limits.memory:   {{- if .limits }}   {{ default $.Values.defaults.limits.memory .limits.memory | quote }}     {{- else }} {{ $.Values.defaults.limits.memory | quote }}   {{- end }}
+    limits.cpu:      {{- if .limits }}   {{ default $.Values.defaults.limits.cpu      .limits.cpu      | quote }} {{- else }} {{ $.Values.defaults.limits.cpu      | quote }} {{- end }}
+    limits.memory:   {{- if .limits }}   {{ default $.Values.defaults.limits.memory   .limits.memory   | quote }} {{- else }} {{ $.Values.defaults.limits.memory   | quote }} {{- end }}
 {{- end }}

--- a/charts/namespaces/values.yaml
+++ b/charts/namespaces/values.yaml
@@ -1,4 +1,5 @@
-defaults: # provides defaults that will be overwritten if specified elsewhere
+# provides defaults that will be overwritten if specified elsewhere
+defaults:
   requests:
     cpu: 2
     memory: 4Gi
@@ -6,10 +7,18 @@ defaults: # provides defaults that will be overwritten if specified elsewhere
     cpu: 4
     memory: 4Gi
 
-common: # rather than overriding the default, appends common with namespace specific values
+# Rather than being overridden like defaults, common values prepend namespace specific values
+common:
   labels:
     common: label
 
+# One can configure a resourceQuota for the following namespaces without it creating the namespaces.
+# This is handled automatically by the chart.
+# - default
+# - kube-system
+# - kube-public
+# - kube-node-lease
+# TODO: The number `0` must be quoted, otherwise it is interpreted as false and skipped over
 namespaces:
   - name: namespace-a
     labels:
@@ -20,5 +29,26 @@ namespaces:
     limits:
       cpu: 3
       memory: 3Gi
-
   - name: namespace-b
+  - name: default
+    requests:
+      cpu: "0"
+      memory: 0Gi
+    limits:
+      cpu: "0"
+      memory: 0Gi
+  - name: kube-system
+  - name: kube-node-lease
+    requests:
+      cpu: "0"
+      memory: 0Gi
+    limits:
+      cpu: "0"
+      memory: 0Gi
+  - name: kube-public
+    requests:
+      cpu: "0"
+      memory: 0Gi
+    limits:
+      cpu: "0"
+      memory: 0Gi


### PR DESCRIPTION
By default, avoids creation of the following namespaces that exist in k8s by default:
- default
- kube-system
- kube-public
- kube-node-lease