### PR TITLE
control plane enhancements

### DIFF
--- a/charts/capi-hcloud-talos/Chart.yaml
+++ b/charts/capi-hcloud-talos/Chart.yaml
@@ -8,4 +8,4 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0

--- a/charts/capi-hcloud-talos/templates/cluster/hetzner-cluster.yaml
+++ b/charts/capi-hcloud-talos/templates/cluster/hetzner-cluster.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ .Values.cluster.name }}
 spec:
   controlPlaneEndpoint:
+    {{- if .Values.controlPlane.hostName }}
     host: {{ .Values.controlPlane.hostName }}
+    {{- end }}
     port: 443
   controlPlaneLoadBalancer:
     region: {{ .Values.cluster.hcloudRegion }}

--- a/charts/capi-hcloud-talos/templates/control-plane/hcloud-machine-template.yaml
+++ b/charts/capi-hcloud-talos/templates/control-plane/hcloud-machine-template.yaml
@@ -9,3 +9,6 @@ spec:
       imageName: {{ .Values.controlPlane.hcloud.imageName }}
       placementGroupName: control-plane
       type: {{ .Values.controlPlane.hcloud.machineType }}
+      publicNetwork:
+        enableIPv4: false
+        enableIPv6: false


### PR DESCRIPTION
- makes control plane endpoint optional
- defaults to no public IPv4 and IPv6 for control plane nodes